### PR TITLE
feat: 도메인 목록 조회 및 상태 변경 api 연결

### DIFF
--- a/src/components/ui/NodataArea.tsx
+++ b/src/components/ui/NodataArea.tsx
@@ -1,0 +1,38 @@
+import clsx from "clsx";
+import Link from "next/link";
+import { Button } from "./Button";
+import { BookX } from "lucide-react";
+
+export interface NodataAreaProps {
+  content?: string;
+  className?: string;
+  linkPath?: string;
+  linkText?: string;
+}
+
+export default function NodataArea({
+  content = "현재 표시할 데이터가 없습니다.",
+  className,
+  linkPath,
+  linkText,
+}: NodataAreaProps) {
+  const isShowLinkButton = linkPath && linkText;
+  return (
+    <div
+      className={clsx(
+        "flex  w-full items-center justify-center py-36",
+        className
+      )}
+    >
+      <div className="flex flex-col w-full items-center justify-center gap-4 lg:gap-8">
+        <BookX className="h-10 w-10 text-gray-400" />
+        <p className="text-sm text-gray-600">{content}</p>
+        {isShowLinkButton && (
+          <Link href={linkPath}>
+            <Button size="md">{linkText}</Button>
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Table.tsx
+++ b/src/components/ui/Table.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { Domain } from "@/types/domain";
+
+// Column 정의
+interface Column {
+  header: string;
+  render: (row: Domain, index: number) => React.ReactNode;
+  className?: string;
+}
+
+interface TableProps {
+  columns: Column[];
+  data: Domain[];
+  rowKey?: (row: Domain) => string | number;
+  tableClassName?: string;
+}
+
+// Table 컴포넌트
+export function Table({
+  columns,
+  data,
+  rowKey,
+  tableClassName = "w-full text-sm text-left text-gray-500",
+}: TableProps) {
+  return (
+    <table className={tableClassName}>
+      <TableHeader columns={columns} />
+      <TableBody columns={columns} data={data} rowKey={rowKey} />
+    </table>
+  );
+}
+
+// Header 컴포넌트
+function TableHeader({ columns }: { columns: Column[] }) {
+  return (
+    <thead className="text-sm text-gray-700 uppercase bg-gray-100">
+      <tr>
+        {columns.map((col, idx) => (
+          <th
+            key={idx}
+            className={`px-6 py-3 font-medium ${col.className || ""}`}
+          >
+            {col.header}
+          </th>
+        ))}
+      </tr>
+    </thead>
+  );
+}
+
+// Body 컴포넌트
+function TableBody({
+  columns,
+  data,
+  rowKey,
+}: {
+  columns: Column[];
+  data: Domain[];
+  rowKey?: (row: Domain) => string | number;
+}) {
+  return (
+    <tbody>
+      {data.map((row, rowIdx) => (
+        <tr
+          key={rowKey ? rowKey(row) : rowIdx}
+          className="bg-white border-b border-gray-300 hover:bg-gray-50"
+        >
+          {columns.map((col, colIdx) => (
+            <td
+              key={colIdx}
+              className={`px-6 py-4 font-medium text-gray-900 ${
+                col.className || ""
+              }`}
+            >
+              {col.render(row, rowIdx)}
+            </td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  );
+}

--- a/src/components/ui/Toggle.tsx
+++ b/src/components/ui/Toggle.tsx
@@ -1,0 +1,24 @@
+interface ToggleProps {
+  enabled: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+}
+
+export function Toggle({ enabled, onChange, disabled }: ToggleProps) {
+  return (
+    <button
+      onClick={() => !disabled && onChange(!enabled)}
+      className={`${
+        enabled ? "bg-primary" : "bg-gray-400"
+      } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none ${
+        disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
+      }`}
+    >
+      <span
+        className={`${
+          enabled ? "translate-x-6" : "translate-x-1"
+        } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
+      />
+    </button>
+  );
+}

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,0 +1,34 @@
+import api from "./axios";
+import { DomainResponse, SingleDomainResponse, Domain } from "@/types/domain";
+
+export const getDomains = async (): Promise<DomainResponse> => {
+  try {
+    const response = await api.get<DomainResponse>("/domains");
+    return response.data; // domain 배열만 반환
+  } catch (error) {
+    console.error("소속 도메인 조회(getDomains) error:", error);
+    return {
+      success: false,
+      data: [],
+    };
+  }
+};
+
+export const updateDomainStatus = async (
+  id: string,
+  isActive: boolean
+): Promise<SingleDomainResponse> => {
+  try {
+    const response = await api.patch<SingleDomainResponse>(`/domains/${id}`, {
+      isActive,
+    });
+    return response.data;
+  } catch (error) {
+    console.error("도메인 상태 변경(updateDomainStatus) error:", error);
+    return {
+      success: false,
+      message: "상태 변경 중 오류가 발생했습니다.",
+      data: {} as Domain,
+    };
+  }
+};

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,0 +1,20 @@
+export interface Domain {
+  id: string;
+  domainUrl: string;
+  siteKey: string;
+  isActive: boolean;
+  organizationId: string;
+  createdAt: string;
+}
+
+export interface DomainResponse {
+  success: boolean;
+  data: Domain[];
+  message?: string;
+}
+
+export interface SingleDomainResponse {
+  success: boolean;
+  data: Domain;
+  message?: string;
+}


### PR DESCRIPTION
이슈번호 : #6 

작업요약 : [도메인] 목록 조회 및 상태 변경 api 연결

### 작업내역
- [X] 테이블 ui 컴포넌트 생성
- [X] '도메인' 목록 조회 api 연결
- [X] '도메인' 상태, 변경 api 연결